### PR TITLE
DE-NONE: Add go ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,8 @@
 version: 2
 updates:
     - package-ecosystem: "gomod"
-      directory: "/go/"
+      directory: "/go"
       reviewers:
-        - "AndrewGutierrezCastro"
-        - "maurigamg"
-        - "Marcosmh0199"
-        - "danielcdz"
+        - "data-engineering-samples/reviewers"
       schedule:
         interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,12 @@
 # Basic set up for package managers
 version: 2
 updates:
+    - package-ecosystem: "gomod"
+      directory: "/go/"
+      reviewers:
+        - "AndrewGutierrezCastro"
+        - "maurigamg"
+        - "Marcosmh0199"
+        - "danielcdz"
+      schedule:
+        interval: "daily"


### PR DESCRIPTION
## Summary
Add go ecosystem to the dependabot file and fix missing final line warning from GitHub.